### PR TITLE
added support for relative return urls

### DIFF
--- a/src/main/java/org/broadleafcommerce/vendor/paypal/service/payment/PayPalRequestGenerator.java
+++ b/src/main/java/org/broadleafcommerce/vendor/paypal/service/payment/PayPalRequestGenerator.java
@@ -33,6 +33,10 @@ public interface PayPalRequestGenerator {
 
     void setAdditionalConfig(Map<String, String> additionalConfig);
 
+    Boolean getUseRelativeUrls();
+
+    void setUseRelativeUrls(Boolean useRelativeUrls);
+
     String getCancelUrl();
 
     void setCancelUrl(String cancelUrl);

--- a/src/main/resources/bl-paypal-applicationContext.xml
+++ b/src/main/resources/bl-paypal-applicationContext.xml
@@ -42,6 +42,7 @@
                 <property name="password" value="${paypal.password}"/>
                 <property name="user" value="${paypal.user}"/>
                 <property name="signature" value="${paypal.signature}"/>
+                <property name="useRelativeUrls" value="${paypal.useRelativeUrls}"/>
                 <property name="returnUrl" value="${paypal.return.url}"/>
                 <property name="cancelUrl" value="${paypal.cancel.url}"/>
                 <!-- 0 : PayPal displays the shipping address passed in. -->

--- a/src/main/resources/config/bc/paypal/development.properties
+++ b/src/main/resources/config/bc/paypal/development.properties
@@ -3,5 +3,6 @@ paypal.password=?
 paypal.signature=?
 paypal.api.url=https://api-3t.sandbox.paypal.com/nvp
 paypal.user.redirect.url=https://www.sandbox.paypal.com/cgi-bin/webscr
+paypal.useRelativeUrls=false
 paypal.return.url=?
 paypal.cancel.url=?

--- a/src/main/resources/config/bc/paypal/integrationdev.properties
+++ b/src/main/resources/config/bc/paypal/integrationdev.properties
@@ -3,5 +3,6 @@ paypal.password=?
 paypal.signature=?
 paypal.api.url=https://api-3t.sandbox.paypal.com/nvp
 paypal.user.redirect.url=https://www.sandbox.paypal.com/cgi-bin/webscr
+paypal.useRelativeUrls=false
 paypal.return.url=?
 paypal.cancel.url=?

--- a/src/main/resources/config/bc/paypal/integrationqa.properties
+++ b/src/main/resources/config/bc/paypal/integrationqa.properties
@@ -3,5 +3,6 @@ paypal.password=?
 paypal.signature=?
 paypal.api.url=https://api-3t.sandbox.paypal.com/nvp
 paypal.user.redirect.url=https://www.sandbox.paypal.com/cgi-bin/webscr
+paypal.useRelativeUrls=false
 paypal.return.url=?
 paypal.cancel.url=?

--- a/src/main/resources/config/bc/paypal/local.properties
+++ b/src/main/resources/config/bc/paypal/local.properties
@@ -3,5 +3,6 @@ paypal.password=?
 paypal.signature=?
 paypal.api.url=https://api-3t.sandbox.paypal.com/nvp
 paypal.user.redirect.url=https://www.sandbox.paypal.com/cgi-bin/webscr
+paypal.useRelativeUrls=false
 paypal.return.url=?
 paypal.cancel.url=?

--- a/src/main/resources/config/bc/paypal/production.properties
+++ b/src/main/resources/config/bc/paypal/production.properties
@@ -3,5 +3,6 @@ paypal.password=?
 paypal.signature=?
 paypal.api.url=https://api-3t.paypal.com/nvp
 paypal.user.redirect.url=https://www.paypal.com/cgi-bin/webscr
+paypal.useRelativeUrls=false
 paypal.return.url=?
 paypal.cancel.url=?

--- a/src/main/resources/config/bc/paypal/staging.properties
+++ b/src/main/resources/config/bc/paypal/staging.properties
@@ -3,5 +3,6 @@ paypal.password=?
 paypal.signature=?
 paypal.api.url=https://api-3t.sandbox.paypal.com/nvp
 paypal.user.redirect.url=https://www.sandbox.paypal.com/cgi-bin/webscr
+paypal.useRelativeUrls=false
 paypal.return.url=?
 paypal.cancel.url=?


### PR DESCRIPTION
The primary use case for this change is when a developer or user uses the IP address or a different host name to access the site. If you are using an absolute url, it will not be valid for the users alternate access path. With relative urls, the hostname is built based upon what the user has entered, fixing this issue. An additional benefit is that you no longer have to set the return url on a per environment basis. Because the host name is dynamic it works for all environments.

In order to help with backwards compatibility I made this feature disabled by default. All you have to do is set the property paypal.useRelativeUrls=true in a properties file and it will work.
