### PR TITLE
Add an extension point to allow implementers to add dynamic custom fields to their Paypal requests

### DIFF
--- a/src/main/java/org/broadleafcommerce/payment/service/gateway/PayPalExpressConfiguration.java
+++ b/src/main/java/org/broadleafcommerce/payment/service/gateway/PayPalExpressConfiguration.java
@@ -17,8 +17,8 @@
  */
 package org.broadleafcommerce.payment.service.gateway;
 
+import org.broadleafcommerce.common.payment.dto.PaymentRequestDTO;
 import org.broadleafcommerce.common.payment.service.PaymentGatewayConfiguration;
-import org.broadleafcommerce.common.payment.service.PaymentGatewayConfigurationService;
 import org.broadleafcommerce.vendor.paypal.service.payment.type.PayPalShippingDisplayType;
 
 import java.util.Map;
@@ -115,16 +115,41 @@ public interface PayPalExpressConfiguration extends PaymentGatewayConfiguration 
     public String getTotalType();
 
     /**
+     * <p>
      * See the PayPal API to see what additional configs you can set:
      * https://developer.paypal.com/docs/classic/api/merchant/SetExpressCheckout_API_Operation_NVP/
-     *
+     * 
+     * <p>
      * e.g. Map<String, String> additionalConfigs = new HashMap<String, String>();
      * additionalConfigs.put("HDRBORDERCOLOR", "FFFFFF");
      * additionalConfigs.put("HDRBACKCOLOR", "FFFFFF");
      * additionalConfigs.put("PAYFLOWCOLOR", "FFFFFF");
+     * 
+     * <p>
+     * This adds additional NVP items to the Paypal request that are ONLY pre-specified in the Paypal API docs.
+     * Any other fields will be ignored. If you want to use completely custom fields, see {@link #getAdditionalCustomFields()}
      *
      * @return Map
      */
     public Map<String, String> getAdditionalConfig();
 
+    /**
+     * <p>
+     * The Paypal NVP API only allows a single field with custom logic in it: PAYMENTREQUEST_n_CUSTOM.
+     * Because of this, all of the fields returned here are serialized together like so:
+     * 
+     * <pre>
+     * {@code ccoc=true_12345|key1=value1|key2=value2|key3=value3}
+     * </pre>
+     * 
+     * <p>
+     * Note that Broadleaf uses a piece of this to determine if we should complete checkout on callback or not. This is done
+     * as "ccoc=true_12345" where {@code true} is the value of {@link PaymentRequestDTO#isCompleteCheckoutOnCallback()}. So,
+     * the minimum string that will be contained in the custom field is {@code ccoc=true_12345}, plus whatever other fields you have.
+     * 
+     * <p>
+     * Also note that the entire custom field string after serialization is 256 characters. An IllegalArgumentException will be thrown
+     * otherwise.
+     */
+    public Map<String, String> getAdditionalCustomFields();
 }

--- a/src/main/java/org/broadleafcommerce/payment/service/gateway/PayPalExpressConfigurationImpl.java
+++ b/src/main/java/org/broadleafcommerce/payment/service/gateway/PayPalExpressConfigurationImpl.java
@@ -132,6 +132,12 @@ public class PayPalExpressConfigurationImpl extends AbstractPaymentGatewayConfig
         additionalConfigs.put("PAYFLOWCOLOR", "FFFFFF");
         return additionalConfigs;
     }
+    
+    @Override
+    public Map<String, String> getAdditionalCustomFields() {
+        // intentionally unimplemented, used as an extension point
+        return new HashMap<String, String>();
+    }
 
     @Override
     public boolean handlesAuthorize() {

--- a/src/main/java/org/broadleafcommerce/vendor/paypal/service/payment/CustomFieldSerializer.java
+++ b/src/main/java/org/broadleafcommerce/vendor/paypal/service/payment/CustomFieldSerializer.java
@@ -1,0 +1,66 @@
+/*
+ * #%L
+ * BroadleafCommerce PayPal
+ * %%
+ * Copyright (C) 2009 - 2017 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+/**
+ * 
+ */
+package org.broadleafcommerce.vendor.paypal.service.payment;
+
+import org.apache.commons.lang.StringUtils;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+
+/**
+ * Serializer for the {@link MessageConstants#DETAILSPAYMENTCUSTOM} field going between a map
+ * and a String.
+ * 
+ * @author Phillip Verheyden (phillipuniverse)
+ */
+@Component("blCustomFieldSerializer")
+public class CustomFieldSerializer {
+
+    protected String serializeCustomFields(Map<String, String> fields) {
+        StringBuffer sb = new StringBuffer();
+        Iterator<Entry<String, String>> fieldsIt = fields.entrySet().iterator();
+        while (fieldsIt.hasNext()) {
+            Entry<String, String> entry = fieldsIt.next();
+            sb.append(entry.getKey());
+            sb.append('=');
+            sb.append(entry.getValue());
+            
+            if (fieldsIt.hasNext()) {
+                sb.append('|');
+            }
+        }
+        return sb.toString();
+    }
+    
+    protected Map<String, String> deserializeCustomFields(String seralized) {
+        Map<String, String> result = new HashMap<String, String>();
+        String[] fields = StringUtils.split(seralized, '|');
+        for (String field : fields) {
+            String[] fieldParts = StringUtils.split(field, '=');
+            result.put(fieldParts[0], fieldParts[1]);
+        }
+        return result;
+    }
+
+}

--- a/src/main/java/org/broadleafcommerce/vendor/paypal/service/payment/MessageConstants.java
+++ b/src/main/java/org/broadleafcommerce/vendor/paypal/service/payment/MessageConstants.java
@@ -4,15 +4,17 @@
  * %%
  * Copyright (C) 2009 - 2014 Broadleaf Commerce
  * %%
- * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
- * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
- * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
- * the Broadleaf End User License Agreement (EULA), Version 1.1
- * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
- * shall apply.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  * 
- * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
- * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  * #L%
  */
 package org.broadleafcommerce.vendor.paypal.service.payment;
@@ -127,6 +129,8 @@ public class MessageConstants {
     public static final String DETAILSPAYMENTTOTALTAX = "PAYMENTREQUEST_n_TAXAMT";
     public static final String DETAILSPAYMENTINVNUM = "PAYMENTREQUEST_n_INVNUM";
     public static final String DETAILSPAYMENTCUSTOM = "PAYMENTREQUEST_n_CUSTOM";
+    public static final int CUSTOMFIELD_CHARACTER_LIMIT = 256;
+    public static final String COMPLETE_CHECKOUT_ON_CALLBACK_CUSTOM_FIELD = "ccoc";
     public static final String DETAILSPAYMENTTRANSACTIONID = "PAYMENTREQUEST_n_TRANSACTIONID";
     public static final String DETAILSPAYMENTALLOWEDMETHOD = "PAYMENTREQUEST_n_ALLOWEDPAYMENTMETHOD";
     public static final String DETAILSPAYMENTREQUESTID = "PAYMENTREQUEST_n_PAYMENTREQUESTID";

--- a/src/main/java/org/broadleafcommerce/vendor/paypal/service/payment/PayPalRequestGenerator.java
+++ b/src/main/java/org/broadleafcommerce/vendor/paypal/service/payment/PayPalRequestGenerator.java
@@ -33,6 +33,8 @@ public interface PayPalRequestGenerator {
 
     Map<String, String> getAdditionalConfig();
 
+    Map<String, String> getAdditionalCustomFields();
+    
     String getCancelUrl();
 
     String getLibVersion();

--- a/src/main/java/org/broadleafcommerce/vendor/paypal/service/payment/PayPalResponseGeneratorImpl.java
+++ b/src/main/java/org/broadleafcommerce/vendor/paypal/service/payment/PayPalResponseGeneratorImpl.java
@@ -65,6 +65,9 @@ public class PayPalResponseGeneratorImpl implements PayPalResponseGenerator {
 
     @Resource(name = "blPayPalExpressConfiguration")
     protected PayPalExpressConfiguration configuration;
+    
+    @Resource
+    protected CustomFieldSerializer customFieldSerializer;
 
     @Override
     public PayPalResponse buildResponse(String response, PayPalRequest paymentRequest) {
@@ -168,7 +171,8 @@ public class PayPalResponseGeneratorImpl implements PayPalResponseGenerator {
         paymentDetails.setPaymentRequestId(getResponseValue(rawResponse, replaceNumericBoundProperty(MessageConstants.DETAILSPAYMENTREQUESTID, new Integer[]{0}, new String[]{"n"})));
 
         String customField = getResponseValue(rawResponse, replaceNumericBoundProperty(MessageConstants.DETAILSPAYMENTCUSTOM, new Integer[]{0}, new String[]{"n"}));
-        String[] parsed = customField.split("_");
+        String checkoutOnCallbackValue = customFieldSerializer.deserializeCustomFields(customField).get(MessageConstants.COMPLETE_CHECKOUT_ON_CALLBACK_CUSTOM_FIELD);
+        String[] parsed = checkoutOnCallbackValue.split("_");
         if (parsed.length != 2) {
             throw new IllegalArgumentException("PAYMENTREQUEST_0_CUSTOM is not constructed correctly - (" + customField +"): " +
                     "should be of the form completeCheckoutBoolean_orderIdLong");


### PR DESCRIPTION
There is an existing extension point in `PayPalExpressConfiguration` for `getAdditionalConfig()`. However, this only allows certain fields [specified in the PayPal API docs for valid NVPs](https://developer.paypal.com/docs/classic/api/merchant/GetExpressCheckoutDetails_API_Operation_NVP/#payment-details-type-fields), and all other fields are unhelpfully ignored. Also, the PayPal API only allows you to send a _single_ custom field.

There is a use case for sending an arbitrary amount of key/value pairs to PayPal that are outside of the API. Since Broadleaf needs to use the custom field already to determine the checkout on callback value, some custom serialization logic was written in order to handle multiple custom fields in the same 256-character string.

Assuming you have a subclass of the `PayPalExpressConfiguration` with an override to `getAdditionalCustomFields()` like this:

```java
public class CustomPayPalConfiguration extends PayPalExpressConfiguration {

    @Override
    public Map<String, String> getAdditionalCustomFields() {
        Map<String, String> fields = new HashMap<>();
        fields.put("customKey", "customValue");
        fields.put("someOtherKey", "someOtherValue");
        return fields;
    }
}
```

And then override the bean in an `applicationContext.xml`:

```xml
<bean id="blPayPalExpressConfiguration" class="com.packagename.CustomPayPalConfiguration" />
```

The following will be added to `PAYMENTREQUEST_0_CUSTOM` NVP:

```
ccoc=true_1234|customKey=customValue|someOtherKey=someOtherValue
```

> Note that the `ccoc` field is added by Broadleaf automatically. Also note that ordering is not guaranteed or preserved in any way

And will come in through the field named `custom` on the PayPal side.