### PR TITLE
Refine transaction error handling & usage of the PayPal-Request-Id header (idempotency key)

### DIFF
--- a/services/src/main/java/org/broadleafcommerce/payment/service/gateway/DefaultPayPalCheckoutTransactionService.java
+++ b/services/src/main/java/org/broadleafcommerce/payment/service/gateway/DefaultPayPalCheckoutTransactionService.java
@@ -98,13 +98,7 @@ public class DefaultPayPalCheckoutTransactionService implements PayPalCheckoutTr
                         PayPalCheckoutPaymentGatewayType.PAYPAL_CHECKOUT);
 
         try {
-            String transactionReferenceId = paymentRequest.getTransactionReferenceId();
-            if (StringUtils.isNotBlank(transactionReferenceId)) {
-                String paymentId =
-                        (String) paymentRequest.getAdditionalField(MessageConstants.PAYMENTID);
-
-                payPalPaymentService.updatePaymentCustom(paymentId, transactionReferenceId);
-            }
+            recordTransactionReferenceIdOnPayment(paymentRequest);
 
             PayPalResource auth = authorizePayment(paymentRequest);
             if (auth instanceof Payment) {
@@ -173,13 +167,7 @@ public class DefaultPayPalCheckoutTransactionService implements PayPalCheckoutTr
                         PayPalCheckoutPaymentGatewayType.PAYPAL_CHECKOUT);
 
         try {
-            String transactionReferenceId = paymentRequest.getTransactionReferenceId();
-            if (StringUtils.isNotBlank(transactionReferenceId)) {
-                String paymentId =
-                        (String) paymentRequest.getAdditionalField(MessageConstants.PAYMENTID);
-
-                payPalPaymentService.updatePaymentCustom(paymentId, transactionReferenceId);
-            }
+            recordTransactionReferenceIdOnPayment(paymentRequest);
 
             PayPalResource salePayment = salePayment(paymentRequest);
             if (salePayment instanceof Payment) {
@@ -362,6 +350,25 @@ public class DefaultPayPalCheckoutTransactionService implements PayPalCheckoutTr
                         capture,
                         paypalCheckoutService.constructAPIContext(paymentRequest)));
         return captureResponse.getCapture();
+    }
+
+    /**
+     * Saves the {@link PaymentRequest#getTransactionReferenceId()} on the {@link Payment}
+     *
+     * @param paymentRequest the object that holds the transactionReferenceId & a reference to the
+     *        Payment
+     * @throws PaymentException thrown if the Payment update fails
+     */
+    protected void recordTransactionReferenceIdOnPayment(
+            @lombok.NonNull PaymentRequest paymentRequest) {
+        String transactionReferenceId = paymentRequest.getTransactionReferenceId();
+
+        if (StringUtils.isNotBlank(transactionReferenceId)) {
+            String paymentId =
+                    (String) paymentRequest.getAdditionalField(MessageConstants.PAYMENTID);
+
+            payPalPaymentService.updatePaymentCustom(paymentId, transactionReferenceId);
+        }
     }
 
     protected PayPalResource authorizePayment(PaymentRequest paymentRequest)

--- a/services/src/main/java/org/broadleafcommerce/payment/service/gateway/PayPalCheckoutRestConfigurationProperties.java
+++ b/services/src/main/java/org/broadleafcommerce/payment/service/gateway/PayPalCheckoutRestConfigurationProperties.java
@@ -25,7 +25,9 @@ import com.broadleafcommerce.paymentgateway.domain.PaymentRequest;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.annotation.PostConstruct;
@@ -150,6 +152,26 @@ public class PayPalCheckoutRestConfigurationProperties {
      */
     @Getter(AccessLevel.NONE)
     private boolean shouldPopulateShippingOnCreatePayment = true;
+
+    /**
+     * The list of transaction failure codes that should be considered a form of payment decline.
+     *
+     * Note: Some failure codes are unclear whether they should be in this list or not. Our
+     * intention is that this list represents payment processing failures (ie the transaction was
+     * declined by the bank, credit card company, etc.) instead of PayPal's validation errors which
+     * would represent a malformed request.
+     */
+    private List<String> paymentDeclineCodes = Arrays.asList(
+            "COMPLIANCE_VIOLATION",
+            "CREDIT_CARD_CVV_CHECK_FAILED",
+            "CREDIT_CARD_REFUSED",
+            "INSTRUMENT_DECLINED",
+            "INSUFFICIENT_FUNDS",
+            "PAYMENT_DENIED",
+            "REFUND_FAILED_INSUFFICIENT_FUNDS",
+            "TRANSACTION_LIMIT_EXCEEDED",
+            "TRANSACTION_REFUSED",
+            "TRANSACTION_REFUSED_BY_PAYPAL_RISK");
 
     /**
      * The Paypal NVP API only allows a single field with custom logic in it:

--- a/services/src/main/java/org/broadleafcommerce/payment/service/gateway/autoconfigure/PayPalServiceAutoConfiguration.java
+++ b/services/src/main/java/org/broadleafcommerce/payment/service/gateway/autoconfigure/PayPalServiceAutoConfiguration.java
@@ -69,9 +69,11 @@ public class PayPalServiceAutoConfiguration {
     @ConditionalOnMissingBean
     public PayPalCheckoutTransactionService payPalCheckoutTransactionService(
             PayPalCheckoutExternalCallService paypalCheckoutService,
-            PayPalPaymentService payPalPaymentService) {
+            PayPalPaymentService payPalPaymentService,
+            PayPalCheckoutRestConfigurationProperties configProperties) {
         return new DefaultPayPalCheckoutTransactionService(paypalCheckoutService,
-                payPalPaymentService);
+                payPalPaymentService,
+                configProperties);
     }
 
     @Bean

--- a/services/src/main/java/org/broadleafcommerce/vendor/paypal/service/PayPalPaymentService.java
+++ b/services/src/main/java/org/broadleafcommerce/vendor/paypal/service/PayPalPaymentService.java
@@ -20,6 +20,8 @@ import com.broadleafcommerce.paymentgateway.domain.PaymentRequest;
 import com.broadleafcommerce.paymentgateway.service.exception.PaymentException;
 import com.paypal.api.payments.Payment;
 
+import lombok.NonNull;
+
 public interface PayPalPaymentService {
 
     /**
@@ -43,6 +45,16 @@ public interface PayPalPaymentService {
      * @throws PaymentException
      * @param paymentRequest
      */
-    void updatePayPalPaymentForFulfillment(PaymentRequest paymentRequest) throws PaymentException;
+    void updatePayPalPaymentForFulfillment(@NonNull PaymentRequest paymentRequest)
+            throws PaymentException;
+
+    /**
+     * Updates the PayPal payment to include the provided custom value.
+     *
+     * @param paymentId the primary identifier of the PayPal Payment
+     * @param custom the value that is to be stored on the PayPal Payment object
+     * @throws PaymentException thrown if the request to update the Payment fails
+     */
+    void updatePaymentCustom(String paymentId, String custom) throws PaymentException;
 
 }

--- a/services/src/main/java/org/broadleafcommerce/vendor/paypal/service/payment/MessageConstants.java
+++ b/services/src/main/java/org/broadleafcommerce/vendor/paypal/service/payment/MessageConstants.java
@@ -51,6 +51,7 @@ public class MessageConstants {
     public static final String MERCHANTPREF_ACCEPTEDPAYMENTTYPE_INSTANT = "INSTANT";
     public static final String HTTP_HEADER_AUTH_ASSERTION = "PayPal-Auth-Assertion";
     public static final String HTTP_HEADER_CLIENT_METADATA_ID = "PayPal-Client-Metadata-Id";
+    public static final String IDEMPOTENCY_KEY = "idempotency_key";
     public static final String HTTP_HEADER_REQUEST_ID = "PayPal-Request-Id";
     public static final String HTTP_HEADER_MOCK_RESPONSE = "PayPal-Mock-Response";
     public static final String BN = "PayPal-Partner-Attribution-Id";
@@ -60,9 +61,9 @@ public class MessageConstants {
     public static final String HTTP_TOKEN = "token";
     public static final String HTTP_BILLINGTOKEN = "billingToken";
     public static final String HTTP_REQUEST = "HTTP_REQUEST";
-    public static final String EXCEPTION_NAME = "EXCEPTION_NAME";
-    public static final String EXCEPTION_MESSAGE = "EXCEPTION_MESSAGE";
-    public static final String EXCEPTION_DEBUG_ID = "EXCEPTION_DEBUG_ID";
+    public static final String ERROR_NAME = "errorName";
+    public static final String ERROR_MESSAGE = "errorMessage";
+    public static final String ERROR_DEBUG_ID = "errorDebugId";
     public static final String CUSTOM_FIELD = "custom_field";
     public static final String TRANSACTION_STATUS = "TRANSACTION_STATUS";
     public static final String PAYMENT_SUBMITTED_TIME = "PAYMENT_SUBMITTED_TIME";


### PR DESCRIPTION
- Refine our specification of PayPal's idempotencyKey (PayPal-Request-Id header) to be based on the request's transactionRequestId instead of the orderId
- Enhance our handling of PayPal error responses & return more informative information via the PaymentResponse
- Ensure that we're storing the transactionReferenceId in the PayPal Payment's 'custom' field so that we can lookup the transaction by this value if we didn't receive the transaction results
- Fix our ability to update Payment properties

https://github.com/BroadleafCommerce/CartOperationServices/issues/101

Requires https://github.com/BroadleafCommerce/PaymentGatewayCommon/pull/10