### PR TITLE
Introduce Spring Retry logic for all externals call to PayPal that encounter a network or 5xx error

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -35,6 +35,10 @@
             <version>1.14.0</version>
         </dependency>
         <dependency>
+            <groupId>org.springframework.retry</groupId>
+            <artifactId>spring-retry</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-collections4</artifactId>
         </dependency>

--- a/services/src/main/java/org/broadleafcommerce/payment/service/gateway/DefaultPayPalCheckoutRetryPolicyClassifier.java
+++ b/services/src/main/java/org/broadleafcommerce/payment/service/gateway/DefaultPayPalCheckoutRetryPolicyClassifier.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2009 - 2020 Broadleaf Commerce
+ *
+ * Licensed under the Broadleaf End User License Agreement (EULA), Version 1.1 (the
+ * "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt).
+ *
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the
+ * "Custom License") between you and Broadleaf Commerce. You may not use this file except in
+ * compliance with the applicable license.
+ *
+ * NOTICE: All information contained herein is, and remains the property of Broadleaf Commerce, LLC
+ * The intellectual and technical concepts contained herein are proprietary to Broadleaf Commerce,
+ * LLC and may be covered by U.S. and Foreign Patents, patents in process, and are protected by
+ * trade secret or copyright law. Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained from Broadleaf Commerce, LLC.
+ */
+package org.broadleafcommerce.payment.service.gateway;
+
+import org.springframework.classify.Classifier;
+import org.springframework.retry.RetryPolicy;
+import org.springframework.retry.policy.NeverRetryPolicy;
+
+import com.paypal.base.rest.PayPalRESTException;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Implementation of a {@link Classifier} that is used to identify a {@link RetryPolicy} based on a
+ * provided {@link Throwable}. If a RetryPolicy is not identified, then a {@link NeverRetryPolicy}
+ * should be returned - ie only retry for specific identified errors.
+ *
+ * @author Chris Kittrell (ckittrell)
+ */
+@RequiredArgsConstructor
+public class DefaultPayPalCheckoutRetryPolicyClassifier
+        implements Classifier<Throwable, RetryPolicy> {
+
+    @Getter(AccessLevel.PROTECTED)
+    private final RetryPolicy retryPolicy;
+
+    @Override
+    public RetryPolicy classify(Throwable throwable) {
+        if (isNetworkError(throwable) || is5xxError(throwable)) {
+            return retryPolicy;
+        }
+
+        return new NeverRetryPolicy();
+    }
+
+    /**
+     * Determines whether or not the given throwable coming from PayPal's SDK is their
+     * representation of a network error
+     *
+     * @param throwable the throwable that is returned by PayPal's SDK
+     * @return whether or not the given throwable represents a network error
+     */
+    protected boolean isNetworkError(Throwable throwable) {
+        if (throwable instanceof PayPalRESTException) {
+            PayPalRESTException restException = (PayPalRESTException) throwable;
+            int httpResponseCode = restException.getResponsecode();
+
+            return (408 == httpResponseCode);
+        }
+
+        return false;
+    }
+
+    /**
+     * Determines whether or not the given throwable coming from PayPal's SDK is their
+     * representation of a 5xx error
+     *
+     * @param throwable the throwable that is returned by PayPal's SDK
+     * @return whether or not the given throwable represents a 5xx error
+     */
+    protected boolean is5xxError(Throwable throwable) {
+        if (throwable instanceof PayPalRESTException) {
+            PayPalRESTException restException = (PayPalRESTException) throwable;
+            int httpResponseCode = restException.getResponsecode();
+
+            return is5xxError(httpResponseCode);
+        }
+
+        return false;
+    }
+
+    private boolean is5xxError(int httpResponseCode) {
+        return (httpResponseCode / 100) == 5;
+    }
+
+}

--- a/services/src/main/java/org/broadleafcommerce/payment/service/gateway/DefaultPayPalCheckoutTransactionService.java
+++ b/services/src/main/java/org/broadleafcommerce/payment/service/gateway/DefaultPayPalCheckoutTransactionService.java
@@ -586,9 +586,6 @@ public class DefaultPayPalCheckoutTransactionService implements PayPalCheckoutTr
                 if (isPaymentDecline(errorCode)) {
                     paymentResponse
                             .failureType(DefaultTransactionFailureTypes.PROCESSING_FAILURE.name());
-                } else if ("INTERNAL_SERVICE_ERROR".equals(errorCode)) {
-                    paymentResponse
-                            .failureType(DefaultTransactionFailureTypes.GATEWAY_ERROR.name());
                 } else {
                     paymentResponse
                             .failureType(DefaultTransactionFailureTypes.INVALID_REQUEST.name());

--- a/services/src/main/java/org/broadleafcommerce/payment/service/gateway/PayPalCheckoutExternalCallService.java
+++ b/services/src/main/java/org/broadleafcommerce/payment/service/gateway/PayPalCheckoutExternalCallService.java
@@ -34,7 +34,17 @@ import com.paypal.base.rest.APIContext;
  */
 public interface PayPalCheckoutExternalCallService {
 
-    PayPalCheckoutRestConfigurationProperties getConfigProperties();
+    /**
+     * Makes a request to PayPal
+     *
+     * @param paymentRequest The payment request that should be executed. The operation that is
+     *        executed is depedent on which implementation of {@link PayPalRequest} is sent
+     * @return the respective PayPalResponse that corresponds to the given PayPalRequest
+     * @throws PaymentException
+     */
+    PayPalResponse call(PayPalRequest paymentRequest) throws PaymentException;
+
+    APIContext constructAPIContext(PaymentRequest paymentRequest);
 
     void setCommonDetailsResponse(AgreementToken response,
             PaymentResponse paymentResponse,
@@ -57,15 +67,4 @@ public interface PayPalCheckoutExternalCallService {
 
     Amount getPayPalAmountFromOrder(PaymentRequest paymentRequest);
 
-    /**
-     * Makes a request to PayPal
-     * 
-     * @param paymentRequest The payment request that should be executed. The operation that is
-     *        executed is depedent on which implementation of {@link PayPalRequest} is sent
-     * @return the respective PayPalResponse that corresponds to the given PayPalRequest
-     * @throws PaymentException
-     */
-    PayPalResponse call(PayPalRequest paymentRequest) throws PaymentException;
-
-    APIContext constructAPIContext(PaymentRequest paymentRequest);
 }

--- a/services/src/main/java/org/broadleafcommerce/vendor/paypal/service/DefaultPayPalAgreementTokenService.java
+++ b/services/src/main/java/org/broadleafcommerce/vendor/paypal/service/DefaultPayPalAgreementTokenService.java
@@ -29,12 +29,18 @@ import com.paypal.api.payments.MerchantPreferences;
 import com.paypal.api.payments.Payer;
 import com.paypal.api.payments.Plan;
 
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class DefaultPayPalAgreementTokenService implements PayPalAgreementTokenService {
 
+    @Getter(AccessLevel.PROTECTED)
     private final PayPalCheckoutExternalCallService paypalCheckoutService;
+
+    @Getter(AccessLevel.PROTECTED)
+    private final PayPalCheckoutRestConfigurationProperties configProperties;
 
     /**
      * To support PayPal Reference Transactions and Billing Agreement Tokens
@@ -60,9 +66,6 @@ public class DefaultPayPalAgreementTokenService implements PayPalAgreementTokenS
     protected Plan constructPlan(PaymentRequest paymentRequest, boolean performCheckoutOnReturn) {
         Plan plan = new Plan();
         plan.setType(MessageConstants.PLAN_TYPE_MERCHANTINITIATEDBILLING);
-
-        PayPalCheckoutRestConfigurationProperties configProperties =
-                paypalCheckoutService.getConfigProperties();
 
         // Set up merchant preferences
         MerchantPreferences merchantPreferences = new MerchantPreferences();
@@ -94,7 +97,7 @@ public class DefaultPayPalAgreementTokenService implements PayPalAgreementTokenS
     }
 
     protected String constructAgreementDescription(PaymentRequest paymentRequest) {
-        return paypalCheckoutService.getConfigProperties().getPaymentDescription();
+        return configProperties.getPaymentDescription();
     }
 
 }

--- a/services/src/main/java/org/broadleafcommerce/vendor/paypal/service/DefaultPayPalBillingAgreementService.java
+++ b/services/src/main/java/org/broadleafcommerce/vendor/paypal/service/DefaultPayPalBillingAgreementService.java
@@ -42,6 +42,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -54,7 +56,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class DefaultPayPalBillingAgreementService implements PayPalBillingAgreementService {
 
+    @Getter(AccessLevel.PROTECTED)
     private final PayPalCheckoutExternalCallService paypalCheckoutService;
+
+    @Getter(AccessLevel.PROTECTED)
+    private final PayPalCheckoutRestConfigurationProperties configProperties;
 
     @Override
     public Agreement createPayPalBillingAgreement(PaymentRequest paymentRequest,
@@ -112,9 +118,6 @@ public class DefaultPayPalBillingAgreementService implements PayPalBillingAgreem
     }
 
     protected Plan constructPlan(PaymentRequest paymentRequest) throws PaymentException {
-        PayPalCheckoutRestConfigurationProperties configProperties =
-                paypalCheckoutService.getConfigProperties();
-
         // Set up merchant preferences
         MerchantPreferences merchantPreferences = new MerchantPreferences();
         merchantPreferences.setCancelUrl(configProperties.getCancelUrl(paymentRequest));

--- a/services/src/main/java/org/broadleafcommerce/vendor/paypal/service/DefaultPayPalPaymentService.java
+++ b/services/src/main/java/org/broadleafcommerce/vendor/paypal/service/DefaultPayPalPaymentService.java
@@ -39,6 +39,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -47,9 +49,19 @@ public class DefaultPayPalPaymentService implements PayPalPaymentService {
     private static final String ADD_OP_TYPE = "add";
     private static final String REPLACE_OP_TYPE = "replace";
 
+    @Getter(AccessLevel.PROTECTED)
     private final PayPalCheckoutExternalCallService paypalCheckoutService;
+
+    @Getter(AccessLevel.PROTECTED)
+    private final PayPalCheckoutRestConfigurationProperties configProperties;
+
+    @Getter(AccessLevel.PROTECTED)
     private final PayPalGatewayConfiguration gatewayConfiguration;
+
+    @Getter(AccessLevel.PROTECTED)
     private final PayPalWebExperienceProfileService webExperienceProfileService;
+
+    @Getter(AccessLevel.PROTECTED)
     private final boolean shouldPopulateShippingOnPaymentCreation;
 
     @Override
@@ -58,9 +70,6 @@ public class DefaultPayPalPaymentService implements PayPalPaymentService {
             throws PaymentException {
         // Set payer details
         Payer payer = constructPayer(paymentRequest);
-
-        PayPalCheckoutRestConfigurationProperties configProperties =
-                paypalCheckoutService.getConfigProperties();
 
         // Set redirect URLs
         RedirectUrls redirectUrls = new RedirectUrls();

--- a/services/src/main/java/org/broadleafcommerce/vendor/paypal/service/DefaultPayPalWebExperienceProfileService.java
+++ b/services/src/main/java/org/broadleafcommerce/vendor/paypal/service/DefaultPayPalWebExperienceProfileService.java
@@ -20,6 +20,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.payment.service.gateway.PayPalCheckoutExternalCallService;
+import org.broadleafcommerce.payment.service.gateway.PayPalCheckoutRestConfigurationProperties;
 import org.broadleafcommerce.vendor.paypal.service.payment.PayPalCreateWebProfileRequest;
 import org.broadleafcommerce.vendor.paypal.service.payment.PayPalCreateWebProfileResponse;
 
@@ -27,21 +28,32 @@ import com.broadleafcommerce.paymentgateway.domain.PaymentRequest;
 import com.broadleafcommerce.paymentgateway.service.exception.PaymentException;
 import com.paypal.api.payments.WebProfile;
 
+import lombok.AccessLevel;
+import lombok.Getter;
+
 public class DefaultPayPalWebExperienceProfileService implements PayPalWebExperienceProfileService {
 
     private static final Log LOG =
             LogFactory.getLog(DefaultPayPalWebExperienceProfileService.class);
 
+    @Getter(AccessLevel.PROTECTED)
     private final PayPalCheckoutExternalCallService paypalCheckoutService;
+
+    @Getter(AccessLevel.PROTECTED)
+    private final PayPalCheckoutRestConfigurationProperties configProperties;
+
+    @Getter(AccessLevel.PROTECTED)
     private final WebProfile webProfile;
 
     private String beanProfileId;
 
     public DefaultPayPalWebExperienceProfileService(
             PayPalCheckoutExternalCallService paypalCheckoutService,
+            PayPalCheckoutRestConfigurationProperties configProperties,
             WebProfile webProfile) {
         super();
         this.paypalCheckoutService = paypalCheckoutService;
+        this.configProperties = configProperties;
         this.webProfile = webProfile;
         if (webProfile != null && StringUtils.isBlank(webProfile.getId()) && LOG.isWarnEnabled()) {
             LOG.warn(
@@ -91,6 +103,6 @@ public class DefaultPayPalWebExperienceProfileService implements PayPalWebExperi
     }
 
     protected String getPropertyWebProfileId() {
-        return paypalCheckoutService.getConfigProperties().getWebProfileId();
+        return configProperties.getWebProfileId();
     }
 }

--- a/services/src/main/java/org/broadleafcommerce/vendor/paypal/service/autoconfigure/PayPalVendorServiceAutoConfiguration.java
+++ b/services/src/main/java/org/broadleafcommerce/vendor/paypal/service/autoconfigure/PayPalVendorServiceAutoConfiguration.java
@@ -40,25 +40,31 @@ public class PayPalVendorServiceAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     public PayPalAgreementTokenService payPalAgreementTokenService(
-            PayPalCheckoutExternalCallService paypalCheckoutService) {
-        return new DefaultPayPalAgreementTokenService(paypalCheckoutService);
+            PayPalCheckoutExternalCallService paypalCheckoutService,
+            PayPalCheckoutRestConfigurationProperties configurationProperties) {
+        return new DefaultPayPalAgreementTokenService(paypalCheckoutService,
+                configurationProperties);
     }
 
     @Bean
     @ConditionalOnMissingBean
     public PayPalBillingAgreementService payPalBillingAgreementService(
-            PayPalCheckoutExternalCallService paypalCheckoutService) {
-        return new DefaultPayPalBillingAgreementService(paypalCheckoutService);
+            PayPalCheckoutExternalCallService paypalCheckoutService,
+            PayPalCheckoutRestConfigurationProperties configurationProperties) {
+        return new DefaultPayPalBillingAgreementService(paypalCheckoutService,
+                configurationProperties);
     }
 
     @Bean
     @ConditionalOnMissingBean
     public PayPalPaymentService payPalPaymentService(
             PayPalCheckoutExternalCallService paypalCheckoutService,
+            PayPalCheckoutRestConfigurationProperties configurationProperties,
             PayPalGatewayConfiguration gatewayConfiguration,
             PayPalWebExperienceProfileService webExperienceProfileService,
             PayPalCheckoutRestConfigurationProperties properties) {
         return new DefaultPayPalPaymentService(paypalCheckoutService,
+                configurationProperties,
                 gatewayConfiguration,
                 webExperienceProfileService,
                 properties.shouldPopulateShippingOnCreatePayment());
@@ -68,8 +74,11 @@ public class PayPalVendorServiceAutoConfiguration {
     @ConditionalOnMissingBean
     public PayPalWebExperienceProfileService payPalWebProfileService(
             PayPalCheckoutExternalCallService paypalCheckoutService,
+            PayPalCheckoutRestConfigurationProperties configurationProperties,
             @Autowired(required = false) WebProfile webProfile) {
-        return new DefaultPayPalWebExperienceProfileService(paypalCheckoutService, webProfile);
+        return new DefaultPayPalWebExperienceProfileService(paypalCheckoutService,
+                configurationProperties,
+                webProfile);
     }
 
 }

--- a/services/src/test/java/org/broadleaf/payment/service/gateway/PayPalCheckoutRetryPolicyClassifierTest.java
+++ b/services/src/test/java/org/broadleaf/payment/service/gateway/PayPalCheckoutRetryPolicyClassifierTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2009 - 2020 Broadleaf Commerce
+ *
+ * Licensed under the Broadleaf End User License Agreement (EULA), Version 1.1 (the
+ * "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt).
+ *
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the
+ * "Custom License") between you and Broadleaf Commerce. You may not use this file except in
+ * compliance with the applicable license.
+ *
+ * NOTICE: All information contained herein is, and remains the property of Broadleaf Commerce, LLC
+ * The intellectual and technical concepts contained herein are proprietary to Broadleaf Commerce,
+ * LLC and may be covered by U.S. and Foreign Patents, patents in process, and are protected by
+ * trade secret or copyright law. Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained from Broadleaf Commerce, LLC.
+ */
+package org.broadleaf.payment.service.gateway;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.broadleafcommerce.payment.service.gateway.DefaultPayPalCheckoutRetryPolicyClassifier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.retry.RetryPolicy;
+import org.springframework.retry.policy.NeverRetryPolicy;
+import org.springframework.retry.policy.SimpleRetryPolicy;
+
+import com.paypal.base.rest.PayPalRESTException;
+
+@Disabled
+public class PayPalCheckoutRetryPolicyClassifierTest {
+
+    DefaultPayPalCheckoutRetryPolicyClassifier retryPolicyClassifier;
+
+    @BeforeEach
+    void setup() {
+        if (retryPolicyClassifier == null) {
+            RetryPolicy retryPolicy = new SimpleRetryPolicy();
+            retryPolicyClassifier = new DefaultPayPalCheckoutRetryPolicyClassifier(retryPolicy);
+        }
+    }
+
+    @Test
+    void testUnknownErrorRetryPolicy() {
+        Throwable throwable = new RuntimeException();
+
+        RetryPolicy retryPolicy = retryPolicyClassifier.classify(throwable);
+
+        assertThat(retryPolicy).isNotNull();
+        assertThat(retryPolicy).isInstanceOf(NeverRetryPolicy.class);
+    }
+
+    @Test
+    void testInvalidRequestRetryPolicy() {
+        Throwable throwable = buildPayPalRESTException(400);
+
+        RetryPolicy retryPolicy = retryPolicyClassifier.classify(throwable);
+
+        assertThat(retryPolicy).isNotNull();
+        assertThat(retryPolicy).isInstanceOf(NeverRetryPolicy.class);
+    }
+
+    @Test
+    void testNetworkErrorRetryPolicy() {
+        Throwable throwable = buildPayPalRESTException(408);
+
+        RetryPolicy retryPolicy = retryPolicyClassifier.classify(throwable);
+
+        assertThat(retryPolicy).isNotNull();
+        assertThat(retryPolicy).isInstanceOf(SimpleRetryPolicy.class);
+    }
+
+    @Test
+    void test5xxErrorRetryPolicy() {
+        Throwable throwable = buildPayPalRESTException(503);
+
+        RetryPolicy retryPolicy = retryPolicyClassifier.classify(throwable);
+
+        assertThat(retryPolicy).isNotNull();
+        assertThat(retryPolicy).isInstanceOf(SimpleRetryPolicy.class);
+    }
+
+    private Throwable buildPayPalRESTException(int httpResponseCode) {
+        PayPalRESTException payPalRESTException = new PayPalRESTException("PayPal REST Exception!");
+        payPalRESTException.setResponsecode(httpResponseCode);
+        return payPalRESTException;
+    }
+
+}


### PR DESCRIPTION
PayPal suggests doing this for all /execute & /capture requests & requires that the idempotencyKey is the same for repeated requests so that the request is not processed more than once. Note, we're also including this retry logic on all other external PayPal calls, but it is not required.

https://github.com/BroadleafCommerce/CartOperationServices/issues/218