### PR TITLE
Fix transaction retry mechanism by moving it to the TransactionService

### DIFF
--- a/services/src/main/java/org/broadleafcommerce/payment/service/gateway/DefaultPayPalCheckoutExternalCallService.java
+++ b/services/src/main/java/org/broadleafcommerce/payment/service/gateway/DefaultPayPalCheckoutExternalCallService.java
@@ -23,7 +23,6 @@ import org.broadleafcommerce.vendor.paypal.service.payment.MessageConstants;
 import org.broadleafcommerce.vendor.paypal.service.payment.PayPalRequest;
 import org.broadleafcommerce.vendor.paypal.service.payment.PayPalResponse;
 import org.springframework.lang.Nullable;
-import org.springframework.retry.support.RetryTemplate;
 
 import com.broadleafcommerce.money.CurrencyContext;
 import com.broadleafcommerce.money.SimpleCurrencyContext;
@@ -71,9 +70,6 @@ public class DefaultPayPalCheckoutExternalCallService
     @Getter(AccessLevel.PROTECTED)
     private final PayPalGatewayConfiguration gatewayConfiguration;
 
-    @Getter(AccessLevel.PROTECTED)
-    private final RetryTemplate retryTemplate;
-
     @Override
     public PayPalResponse call(PayPalRequest paymentRequest) {
         return super.process(paymentRequest);
@@ -81,7 +77,7 @@ public class DefaultPayPalCheckoutExternalCallService
 
     @Override
     public PayPalResponse communicateWithVendor(PayPalRequest paymentRequest) throws Exception {
-        return retryTemplate.execute(context -> paymentRequest.execute());
+        return paymentRequest.execute();
     }
 
     @Override

--- a/services/src/main/java/org/broadleafcommerce/payment/service/gateway/DefaultPayPalCheckoutRetryPolicyClassifier.java
+++ b/services/src/main/java/org/broadleafcommerce/payment/service/gateway/DefaultPayPalCheckoutRetryPolicyClassifier.java
@@ -57,8 +57,9 @@ public class DefaultPayPalCheckoutRetryPolicyClassifier
      * @return whether or not the given throwable represents a network error
      */
     protected boolean isNetworkError(Throwable throwable) {
-        if (throwable instanceof PayPalRESTException) {
-            PayPalRESTException restException = (PayPalRESTException) throwable;
+        Throwable cause = throwable.getCause();
+        if (cause instanceof PayPalRESTException) {
+            PayPalRESTException restException = (PayPalRESTException) cause;
             int httpResponseCode = restException.getResponsecode();
 
             return (408 == httpResponseCode);
@@ -75,8 +76,9 @@ public class DefaultPayPalCheckoutRetryPolicyClassifier
      * @return whether or not the given throwable represents a 5xx error
      */
     protected boolean is5xxError(Throwable throwable) {
-        if (throwable instanceof PayPalRESTException) {
-            PayPalRESTException restException = (PayPalRESTException) throwable;
+        Throwable cause = throwable.getCause();
+        if (cause instanceof PayPalRESTException) {
+            PayPalRESTException restException = (PayPalRESTException) cause;
             int httpResponseCode = restException.getResponsecode();
 
             return is5xxError(httpResponseCode);

--- a/services/src/main/java/org/broadleafcommerce/payment/service/gateway/autoconfigure/PayPalServiceAutoConfiguration.java
+++ b/services/src/main/java/org/broadleafcommerce/payment/service/gateway/autoconfigure/PayPalServiceAutoConfiguration.java
@@ -57,6 +57,22 @@ public class PayPalServiceAutoConfiguration {
         return new DefaultPayPalGatewayConfiguration();
     }
 
+    @Bean
+    @ConditionalOnMissingBean
+    public PayPalCheckoutExternalCallService payPalCheckoutExternalCallService(
+            PayPalCheckoutRestConfigurationProperties configProperties,
+            PayPalGatewayConfiguration gatewayConfiguration) {
+        return new DefaultPayPalCheckoutExternalCallService(configProperties,
+                gatewayConfiguration);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public PayPalSyncTransactionService payPalSyncTransactionService(
+            PayPalCheckoutExternalCallService paypalCheckoutService) {
+        return new DefaultPayPalSyncTransactionService(paypalCheckoutService);
+    }
+
     /**
      * Retries 3 times with a second between each attempt when a network or 5xx error is encountered
      */
@@ -79,31 +95,15 @@ public class PayPalServiceAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public PayPalCheckoutExternalCallService payPalCheckoutExternalCallService(
-            PayPalCheckoutRestConfigurationProperties configProperties,
-            PayPalGatewayConfiguration gatewayConfiguration,
-            @Qualifier("payPalCheckoutExternalCallRetryTemplate") RetryTemplate retryTemplate) {
-        return new DefaultPayPalCheckoutExternalCallService(configProperties,
-                gatewayConfiguration,
-                retryTemplate);
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
-    public PayPalSyncTransactionService payPalSyncTransactionService(
-            PayPalCheckoutExternalCallService paypalCheckoutService) {
-        return new DefaultPayPalSyncTransactionService(paypalCheckoutService);
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
     public PayPalCheckoutTransactionService payPalCheckoutTransactionService(
             PayPalCheckoutExternalCallService paypalCheckoutService,
             PayPalPaymentService payPalPaymentService,
-            PayPalCheckoutRestConfigurationProperties configProperties) {
+            PayPalCheckoutRestConfigurationProperties configProperties,
+            @Qualifier("payPalCheckoutExternalCallRetryTemplate") RetryTemplate retryTemplate) {
         return new DefaultPayPalCheckoutTransactionService(paypalCheckoutService,
                 payPalPaymentService,
-                configProperties);
+                configProperties,
+                retryTemplate);
     }
 
     @Bean

--- a/services/src/test/java/org/broadleaf/payment/service/gateway/PayPalCheckoutTransactionServiceTest.java
+++ b/services/src/test/java/org/broadleaf/payment/service/gateway/PayPalCheckoutTransactionServiceTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2009 - 2020 Broadleaf Commerce
+ *
+ * Licensed under the Broadleaf End User License Agreement (EULA), Version 1.1 (the
+ * "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt).
+ *
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the
+ * "Custom License") between you and Broadleaf Commerce. You may not use this file except in
+ * compliance with the applicable license.
+ *
+ * NOTICE: All information contained herein is, and remains the property of Broadleaf Commerce, LLC
+ * The intellectual and technical concepts contained herein are proprietary to Broadleaf Commerce,
+ * LLC and may be covered by U.S. and Foreign Patents, patents in process, and are protected by
+ * trade secret or copyright law. Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained from Broadleaf Commerce, LLC.
+ */
+package org.broadleaf.payment.service.gateway;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.broadleafcommerce.payment.service.gateway.DefaultPayPalCheckoutRetryPolicyClassifier;
+import org.broadleafcommerce.payment.service.gateway.DefaultPayPalCheckoutTransactionService;
+import org.broadleafcommerce.payment.service.gateway.PayPalCheckoutExternalCallService;
+import org.broadleafcommerce.payment.service.gateway.PayPalCheckoutRestConfigurationProperties;
+import org.broadleafcommerce.vendor.paypal.service.PayPalPaymentService;
+import org.broadleafcommerce.vendor.paypal.service.payment.PayPalRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.classify.Classifier;
+import org.springframework.retry.RetryPolicy;
+import org.springframework.retry.backoff.FixedBackOffPolicy;
+import org.springframework.retry.policy.ExceptionClassifierRetryPolicy;
+import org.springframework.retry.policy.SimpleRetryPolicy;
+import org.springframework.retry.support.RetryTemplate;
+
+import com.broadleafcommerce.paymentgateway.domain.PaymentRequest;
+import com.broadleafcommerce.paymentgateway.domain.PaymentResponse;
+import com.broadleafcommerce.paymentgateway.domain.enums.DefaultTransactionFailureTypes;
+import com.broadleafcommerce.paymentgateway.service.exception.PaymentException;
+import com.paypal.api.payments.Error;
+import com.paypal.base.rest.PayPalRESTException;
+
+@ExtendWith(MockitoExtension.class)
+public class PayPalCheckoutTransactionServiceTest {
+
+    DefaultPayPalCheckoutTransactionService transactionService;
+
+    @Mock
+    PayPalCheckoutExternalCallService externalCallService;
+
+    @Mock
+    PayPalPaymentService payPalPaymentService;
+
+    @Mock
+    PayPalCheckoutRestConfigurationProperties configProperties;
+
+    @BeforeEach
+    void setup() {
+        if (transactionService == null) {
+            RetryTemplate retryTemplate = new RetryTemplate();
+
+            ExceptionClassifierRetryPolicy retryPolicy = new ExceptionClassifierRetryPolicy();
+            Classifier<Throwable, RetryPolicy> classifier =
+                    new DefaultPayPalCheckoutRetryPolicyClassifier(new SimpleRetryPolicy());
+            retryPolicy.setExceptionClassifier(classifier);
+            retryTemplate.setRetryPolicy(retryPolicy);
+
+            FixedBackOffPolicy backOffPolicy = new FixedBackOffPolicy();
+            retryTemplate.setBackOffPolicy(backOffPolicy);
+
+            transactionService = new DefaultPayPalCheckoutTransactionService(
+                    externalCallService,
+                    payPalPaymentService,
+                    configProperties,
+                    retryTemplate);
+
+            PayPalRESTException payPalRESTException =
+                    new PayPalRESTException("Network error!");
+            payPalRESTException.setResponsecode(408);
+            payPalRESTException.setDetails(new Error());
+            when(externalCallService.call(any()))
+                    .thenThrow(new PaymentException(payPalRESTException));
+        }
+    }
+
+    @Test
+    void testTransactionRetryForNetworkError() {
+        PaymentRequest paymentRequest = new PaymentRequest();
+
+        PaymentResponse response = transactionService.authorize(paymentRequest);
+
+        assertThat(response.isSuccessful()).isFalse();
+        assertThat(response.getFailureType())
+                .isEqualTo(DefaultTransactionFailureTypes.NETWORK_ERROR.name());
+        verify(externalCallService, times(3)).call(any(PayPalRequest.class));
+    }
+
+}


### PR DESCRIPTION
- Shift the usage of the RetryTemplate to the TransactionService layer so that we can produce different PayPalRequests & correctly retry. PayPalRequests have a mechanism that ensures that the request is only sent once, so we need to produce a new request for each retry. With that being said, the APIContext must be same so that the idempotencyKey is the same
- Introduce a test for the retry mechanism

https://github.com/BroadleafCommerce/CartOperationServices/issues/218