### PR TITLE
Remove unused java.version property in favor of inheriting maven.compiler.release from MicroservicesBase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.broadleafcommerce.microservices</groupId>
         <artifactId>broadleaf-common-parent</artifactId>
-        <version>1.7.17-SNAPSHOT</version>
+        <version>1.7.22-SNAPSHOT</version>
         <relativePath />
     </parent>
 
@@ -24,7 +24,7 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.uri>${user.dir}</project.uri>
-        <java.version>17</java.version>
+
     </properties>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,6 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.uri>${user.dir}</project.uri>
-
     </properties>
 
     <repositories>


### PR DESCRIPTION
https://github.com/BroadleafCommerce/MicroPM/issues/3870

Tests:
```shell
# Verify compiler release property is set correctly
mvn help:effective-pom | grep -B 4 -A 4 'maven.compiler.release'

# Verify compiler args (only release matters - expect source/target to be defaulted)
mvn -X compile | grep -A 10 -B 10 -E 'release ='

# Verify output class versions
mvn clean package -DskipTests && javap -verbose "$(find . -type f -path '**/target/classes/*.class' | head -1)" | grep major
```

# After merging, ensure to rebase the `feature-sb3` branch on the latest `develop`